### PR TITLE
fix: relax requirement for engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^3.3.4000"
   },
   "engines": {
-    "node": "^8.15"
+    "node": ">=8.3"
   },
   "peerDependencies": {
     "semantic-release": "^15.13.3"


### PR DESCRIPTION
Use [the same one with semantic-release core](https://github.com/semantic-release/semantic-release/blob/a90a1038e7acb39eb30558cde18b628078fbd1f3/package.json#L72).
