### PR TITLE
feat(task): add error output to publish task

### DIFF
--- a/src/gradle.ts
+++ b/src/gradle.ts
@@ -84,7 +84,12 @@ export function getTaskToPublish(
             reject(new Error(ERROR_MULTIPLE_PLUGIN));
           }
           task = "publishPlugins";
+        } else {
+          logger.debug(line.toString())
         }
+      });
+      child.stderr.pipe(split()).on("data", (line: string) => {
+          logger.error(line.toString())
       });
       child.on("close", (code: number) => {
         if (code !== 0) {


### PR DESCRIPTION
The internal gradle task now prints detailed error outputs to the console.

Closes #288