### PR TITLE
fix: support Node.JS 16.14.0 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.0.2"
   },
   "engines": {
-    "node": "~16.13.1"
+    "node": "^16.14.0"
   },
   "peerDependencies": {
     "semantic-release": "^19.0.2"


### PR DESCRIPTION
In a project depending on this gradle-semantic-release-plugin, `npm i` command reports the following error:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'gradle-semantic-release-plugin@1.6.6',
npm WARN EBADENGINE   required: { node: '~16.13.1' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm: '8.3.1' }
npm WARN EBADENGINE }
```

This PR will fix it by changing `engine.node` config in the `package.json`.