### PR TITLE
Support NodeJS v17 explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 17]
+        node-version: [14, 16, 17]
     steps:
       - name: Decide the ref to check out
         uses: haya14busa/action-cond@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on: [push, pull_request_target]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node-version: [16, 17]
     steps:
       - name: Decide the ref to check out
         uses: haya14busa/action-cond@v1
@@ -28,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -44,8 +46,10 @@ jobs:
         run: |
           npm ci
           npm test
+      - name: Run semantic-release
+        if: matrix.node-version == 16
+        run: |
           npm run semantic-release
         env:
-          CI: true
           GITHUB_TOKEN: ${{ secrets.PAT_TO_PUSH }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=16 || ^14.17"
   },
   "peerDependencies": {
     "semantic-release": "^19.0.2"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.0.2"
   },
   "engines": {
-    "node": "^16.14.0"
+    "node": ">=16"
   },
   "peerDependencies": {
     "semantic-release": "^19.0.2"


### PR DESCRIPTION
Use the same `engine.node` configuration with [semantic-release core](https://github.com/semantic-release/semantic-release/blob/2b94bb4e0967c705ab92deace342f9fecb02909d/package.json#L73).

close #466