### PR TITLE
chore: add debug logging

### DIFF
--- a/src/gradle.ts
+++ b/src/gradle.ts
@@ -167,6 +167,10 @@ export function getVersion(
       child.on("error", (err) => {
         reject(err);
       });
+      child.stderr &&
+        child.stderr.pipe(split()).on("data", (line: string) => {
+          console.debug(line);
+        });
     }
   });
 }


### PR DESCRIPTION
Add debug logs in case of an error during prepare step.

The existing logs aren't enough to debug issues and I had to spend significant time trying to figure out why this plugin was failing. Ultimately, the code that is implemented here helped. 

I would've hoped the code block implemented here would be written inside `child.on(error)` block, but that block does not get triggered even when the exit code is 1. I'm not sure why that happens.