### PR TITLE
Support latest artifactory plugin

### DIFF
--- a/src/gradle.ts
+++ b/src/gradle.ts
@@ -79,12 +79,13 @@ export function getTaskToPublish(
           if (
             tasks.length !== 0 &&
             tasks[0] !== "artifactoryDeploy" &&
+            tasks[0] !== "artifactoryPublish" &&
             tasks[0] !== "publishPlugins" &&
             tasks[0] !== "publishToSonatype"
           ) {
             reject(new Error(ERROR_MULTIPLE_PLUGIN));
           }
-          if (tasks.length != 0 && tasks[0] === "artifactoryDeploy") {
+          if (tasks.length != 0 && (tasks[0] === "artifactoryDeploy" || tasks[0] === "artifactoryPublish")) {
             logger.info(INFO_ARTIFACTORY);
           } else if (tasks.length != 0 && tasks[0] === "publishPlugins") {
             logger.info(INFO_PUBLISH_PLUGINS);

--- a/src/gradle.ts
+++ b/src/gradle.ts
@@ -65,6 +65,15 @@ export function getTaskToPublish(
             logger.info(INFO_ARTIFACTORY);
           }
           tasks = ["artifactoryDeploy"];
+        } else if (line.startsWith("artifactoryPublish -")) {
+          // Plugins Gradle Artifactory Plugin and Maven Publish Plugin are often used together
+          if (tasks.length !== 0 && tasks[0] !== "publish") {
+            reject(new Error(ERROR_MULTIPLE_PLUGIN));
+          }
+          if (tasks.length !== 0 && tasks[0] === "publish") {
+            logger.info(INFO_ARTIFACTORY);
+          }
+          tasks = ["artifactoryPublish"];
         } else if (line.startsWith("publish -")) {
           // Plugins Gradle Artifactory Plugin and Maven Publish Plugin are often used together
           if (

--- a/test/project/with-artifactory-plugin/build.gradle
+++ b/test/project/with-artifactory-plugin/build.gradle
@@ -1,6 +1,6 @@
 // https://www.jfrog.com/confluence/display/RTF/Gradle+Artifactory+Plugin
 plugins {
-    id "com.jfrog.artifactory" version "4.9.6"
+    id "com.jfrog.artifactory" version "5.2.5"
 }
 
 apply plugin: 'maven-publish'

--- a/test/src/gradle.test.ts
+++ b/test/src/gradle.test.ts
@@ -57,14 +57,14 @@ describe("Test for gradle handling", function () {
       );
       expect(task).toEqual(["uploadArchives"]);
     });
-    it("returns 'artifactoryDeploy' when there is available artifactory-plugin", async () => {
+    it("returns 'artifactoryPublish' when there is available artifactory-plugin", async () => {
       const gradleProject = join(cwd(), "test/project/with-artifactory-plugin");
       const task = await getTaskToPublish(
         gradleProject,
         process.env,
         new Signale(),
       );
-      expect(task).toEqual(["artifactoryDeploy"]);
+      expect(task).toEqual(["artifactoryPublish"]);
     });
     it("returns 'publishPlugins' when there is available plugin-publish-plugin", async () => {
       const gradleProject = join(


### PR DESCRIPTION
Builds in the latest `master` branch are broken, because old artifactory library has been removed from the Maven Central.
This PR supports the latest artifactory plugin, and bumps up the library in test case.