### PR TITLE
Simplify actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
           java-version: "21"
           distribution: "temurin"
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          dependency-graph: generate-and-submit
       - name: Download Gradle
         run: |
           cd test/project/with-artifactory-plugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,25 +8,12 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22]
+    permissions:
+      contents: write
     steps:
-      - name: Decide the ref to check out
-        uses: haya14busa/action-cond@v1
-        id: condval
-        with:
-          cond: ${{ github.event_name == 'pull_request_target' }}
-          if_true: refs/pull/${{ github.event.pull_request.number }}/merge
-          if_false: ${{ github.ref }}
       - uses: actions/checkout@v4
         with:
-          ref: ${{ steps.condval.outputs.value }}
           fetch-depth: 0
-          # Make sure the release step uses its own credentials.
-          persist-credentials: false
-      - name: Resolve detached branch
-        run: |
-          git checkout -b detached-branch
-          git branch --track master origin/master
-        if: github.event_name == 'pull_request_target'
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -52,5 +39,5 @@ jobs:
         run: |
           npm run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TO_PUSH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: "17"
           distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: "21"


### PR DESCRIPTION
- we do not use `pull_request_target` in this repo, then simply remove needless `haya14busa/action-cond` etc.
- bump up actions used in the workflow.
- <del>bump up JDK to run Gradle.</del>